### PR TITLE
Handle empty sub titles and complex AMD-type struct divs

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -5,6 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Treat nested AMD-type (non-logical) divs in logical struct map (i.e.
+newspaper case)
+
+### Changed
+- Make extraction of subtitles conditional on their presence
 
 ## [0.1.0] - 2019-12-04
 ### Added

--- a/mets_mods2tei/api/mets.py
+++ b/mets_mods2tei/api/mets.py
@@ -124,8 +124,10 @@ class Mets:
 
         #
         # sub titles
-        self.sub_titles = [sub_title.get_valueOf_().strip() for sub_title in self.mods.get_titleInfo()[0].get_subTitle()]
-
+        self.sub_titles = []
+        for title_info in self.mods.get_titleInfo():
+            for sub_title in title_info.get_subTitle():
+                self.sub_titles.append(sub_title.get_valueOf_().strip())
         #
         # authors and editors
         self.authors = []

--- a/mets_mods2tei/api/tei.py
+++ b/mets_mods2tei/api/tei.py
@@ -645,22 +645,31 @@ class Tei:
         # div structure has to be added to text
         text = self.tree.xpath('//tei:text', namespaces=ns)[0]
 
+        # relevant divs
+        struct_divs = list(filter(lambda x: x.get_ADMID() is None, div.get_div()))
+        amd_divs = list(filter(lambda x: x.get_ADMID() is not None, div.get_div()))
+
         # do not add front node to unstructured volumes
-        if div.get_div():
+        if struct_divs:
             front = etree.SubElement(text, "%sfront" % TEI)
 
         # body must be present
         body = etree.SubElement(text, "%sbody" % TEI)
 
         # do not add back node to unstructured volumes
-        if div.get_div():
+        if struct_divs:
             back = etree.SubElement(text, "%sback" % TEI)
         else:
             # default div for unstructured volumes
             body = etree.SubElement(body, "%sdiv" % TEI)
+            # newspaper case: decent to the deepest div!
+            if amd_divs:
+                div = amd_divs[0]
+                while div.get_div():
+                    div = div.get_div()[0]
             body.set("id", div.get_ID())
 
-        for sub_div in div.get_div():
+        for sub_div in struct_divs:
             if sub_div.get_TYPE() == "title_page":
                 self.__add_div(front, sub_div, 1, "titlePage")
             elif sub_div.get_TYPE() == "chapter" or sub_div.get_TYPE() == "section":


### PR DESCRIPTION
An index error caused by non-existent sub titles has been dealt
with. Complex AMD-type divs were previously ignored resulting
in missing text.