### PR TITLE
Add special treatment for URNs and VD IDs

### DIFF
--- a/mets_mods2tei/api/mets.py
+++ b/mets_mods2tei/api/mets.py
@@ -72,7 +72,8 @@ class Mets:
         self.encoding_desc = None
         self.owner_manuscript = None
         self.shelf_locators = None
-        self.identifiers = None
+        self.urn = None
+        self.vd_id = None
         self.scripts = None
         self.collections = None
         self.languages = None
@@ -246,12 +247,15 @@ class Mets:
                 self.owner_manuscript = location.get_physicalLocation()
 
         #
-        # identifiers
-        self.identifiers = []
+        # URN and VD ID
+        self.urn = ""
+        self.vd_id = ""
         identifiers = self.mods.get_identifier()
         for identifier in identifiers:
-            self.identifiers.append((identifier.get_type(), identifier.get_valueOf_()))
-
+            if identifier.get_type().lower() == "urn":
+                self.urn = identifier.get_valueOf_()
+            elif identifier.get_type().lower().startswith("vd"):
+                self.vd_id = identifier.get_valueOf_()
 
         #
         # collections (from relatedItem)
@@ -392,11 +396,17 @@ class Mets:
         """
         return self.shelf_locators
 
-    def get_identifiers(self):
+    def get_urn(self):
         """
-        Return the mods identifiers as a attribut-value mapping
+        Return the URN of the digital representation
         """
-        return self.identifiers
+        return self.urn
+
+    def get_vd_id(self):
+        """
+        Return the VD ID of the digital representation
+        """
+        return self.vd_id
 
     def get_scripts(self):
         """

--- a/mets_mods2tei/api/tei.py
+++ b/mets_mods2tei/api/tei.py
@@ -101,8 +101,10 @@ class Tei:
             self.add_shelfmark(shelf_locator)
 
         # identifiers
-        if mets.get_identifiers():
-            self.add_identifiers(mets.get_identifiers())
+        if mets.get_urn():
+            self.add_urn(mets.get_urn())
+        if mets.get_vd_id():
+            self.add_vd_id(mets.get_vd_id())
 
         # type description
         if mets.get_scripts():
@@ -269,11 +271,26 @@ class Tei:
         return [shelfmark.text for shelfmark in self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno/tei:idno[@type="shelfmark"]', namespaces=ns)]
 
     @property
-    def identifiers(self):
+    def urn(self):
         """
-        Return information on the TEI-Header-represented work's (abstract) identifiers.
+        Return information on the TEI-Header-represented work's URN.
         """
-        return [(identifier.get("type", default=""), identifier.text) for identifier in self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno/tei:idno[@type!="shelfmark"]', namespaces=ns)]
+        urn = self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno/tei:idno[@type="URN"]', namespaces=ns)
+        if urn:
+            return urn[0].text
+        else:
+            return ""
+
+    @property
+    def vd_id(self):
+        """
+        Return information on the TEI-Header-represented work's VD ID.
+        """
+        vd_id = self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno/tei:idno[@type="VD"]', namespaces=ns)
+        if vd_id:
+            return vd_id[0].text
+        else:
+            return ""
 
     @property
     def extents(self):
@@ -457,7 +474,7 @@ class Tei:
 
     def add_repository(self, repository):
         """
-        Adds the repository of the (original) manuscript
+        Add the repository of the (original) manuscript
         """
         ms_ident = self.tree.xpath('//tei:msDesc/tei:msIdentifier', namespaces=ns)[0]
         repository_node = etree.SubElement(ms_ident, "%srepository" % TEI)
@@ -472,15 +489,23 @@ class Tei:
         idno.set("type", "shelfmark")
         idno.text = shelfmark
 
-    def add_identifiers(self, identifiers):
+    def add_urn(self, urn):
         """
-        Adds the identifiers of the digital edition
+        Add the URN of the digital edition
         """
         ms_ident_idno = self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno', namespaces=ns)[0]
-        for identifier in identifiers:
-            idno = etree.SubElement(ms_ident_idno, "%sidno" % TEI)
-            idno.set("type", identifier[0])
-            idno.text = identifier[1]
+        idno = etree.SubElement(ms_ident_idno, "%sidno" % TEI)
+        idno.set("type", "URN")
+        idno.text = urn
+
+    def add_vd_id(self, vd_id):
+        """
+        Add the VD ID of the digital edition
+        """
+        ms_ident_idno = self.tree.xpath('//tei:msDesc/tei:msIdentifier/tei:idno', namespaces=ns)[0]
+        idno = etree.SubElement(ms_ident_idno, "%sidno" % TEI)
+        idno.set("type", "VD")
+        idno.text = vd_id
 
     def set_type_desc(self, description):
         """

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -111,3 +111,9 @@ def test_data_assignment(subtests, datadir):
 
     with subtests.test("Check shelf locator(s)"):
         assert(mets.get_shelf_locators() == ['Hist.Amer.1497'])
+
+    with subtests.test("Check URN"):
+        assert(mets.get_urn() == 'urn:nbn:de:bsz:14-db-id4971666239')
+
+    with subtests.test("Check VD ID"):
+        assert(mets.get_vd_id() == 'VD18 11413883')

--- a/tests/test_tei.py
+++ b/tests/test_tei.py
@@ -101,9 +101,13 @@ def test_data_assignment(subtests):
         tei.add_shelfmark("HAL 9000")
         assert(tei.shelfmarks == ["Foo 25", "HAL 9000"])
 
-    with subtests.test("Check identifiers"):
-        tei.add_identifiers([("Collection", "VD 18")])
-        assert(tei.identifiers == [("Collection", "VD 18")])
+    with subtests.test("Check VD ID"):
+        tei.add_vd_id("VD18 11413883")
+        assert(tei.vd_id == "VD18 11413883")
+
+    with subtests.test("Check URN"):
+        tei.add_urn("urn:nbn:de:bsz:14-db-id4971666239")
+        assert(tei.urn == "urn:nbn:de:bsz:14-db-id4971666239")
 
     with subtests.test("Check first extent"):
         tei.add_extent("32 S.")


### PR DESCRIPTION
DTABf only allows for a closed set of IDs
(cf.
http://www.deutschestextarchiv.de/doku/basisformat/mdSdMsDesc.html).
With this commit the general set of identifiers has been replaced
by two specific IDs: URN and VD ID. Others are ignored.

Fixes https://github.com/slub/mets-mods2tei/issues/37