### PR TITLE
Add exception handling for language code expansion

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Added tests for TEI API
+- Added tests for insertion index identification
 - Evaluate texts from all struct types but `binding` and `colour_checker`
 - Add `front`, `body` and `back` per default
 
 ### Fixed
 - https://github.com/slub/mets-mods2tei/issues/43
+- https://github.com/slub/mets-mods2tei/issues/47
 
 ## [0.1.1] - 2020-05-11
 ### Added

--- a/mets_mods2tei/api/mets.py
+++ b/mets_mods2tei/api/mets.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
 from lxml import etree
+
 import os
+import logging
 import csv
 import babel
 
@@ -79,6 +81,9 @@ class Mets:
         self.languages = None
         self.extents = None
         self.series = None
+
+        # logging
+        self.logger = logging.getLogger(__name__)
 
     @classmethod
     def read(cls, source):
@@ -182,7 +187,11 @@ class Mets:
         self.scripts = []
         for language in languages:
             for language_term in language.get_languageTerm():
-                self.languages[language_term.get_valueOf_()] = babel.Locale.parse(language_term.get_valueOf_()).get_language_name('de')
+                try:
+                    self.languages[language_term.get_valueOf_()] = babel.Locale.parse(language_term.get_valueOf_()).get_language_name('de')
+                except babel.core.UnknownLocaleError as err:
+                    self.logger.error("{0}. Falling back to 'Unbekannt'".format(err))
+                    self.languages[language_term.get_valueOf_()] = "Unbekannt"
             for script_term in language.get_scriptTerm():
                 self.scripts.append(self.script_iso.get(script_term.get_valueOf_()))
         if not self.languages:

--- a/tests/test_alto.py
+++ b/tests/test_alto.py
@@ -76,3 +76,11 @@ def test_text_line_text_extraction(datadir):
     text_block = list(alto.get_text_blocks())[0]
     text_line = list(alto.get_lines_in_text_block(text_block))[0]
     assert(alto.get_text_in_line(text_line) == "Vorbericht.")
+
+def test_index_assingment(datadir):
+    '''
+    Test the identifcation of the most likely insertion index
+    '''
+    with open(datadir.join('test_alto.xml'), 'rb') as f:
+        alto = Alto.read(f)
+        assert(alto.get_best_insert_index("Vorbericht") == (0,0))


### PR DESCRIPTION
Some libraries use non-iso-conform languages codes (e.g. *lat*
for *Latin* in
https://content.staatsbibliothek-berlin.de/dc/PPN647473836.mets.xml)
This PR adds exception handling for `UnknownLocaleError` and some
testing to increase general test coverage.

Fixes https://github.com/slub/mets-mods2tei/issues/47