### PR TITLE
Add TEI corresp references

### DIFF
--- a/mets_mods2tei/api/tei.py
+++ b/mets_mods2tei/api/tei.py
@@ -35,6 +35,7 @@ class Tei:
 
         # logging
         self.logger = logging.getLogger(__name__)
+        self.corresp = []
 
     def tostring(self):
         """
@@ -44,11 +45,13 @@ class Tei:
         etree.indent(self.tree, space="  ")
         return etree.tostring(self.tree, pretty_print=True, encoding="utf-8")
 
-    def fill_from_mets(self, mets, ocr=True):
+    def fill_from_mets(self, mets, ocr=True, corresp=None):
         """
         Fill the contents of the TEI object from a METS instance
         """
 
+        if corresp:
+            self.corresp = corresp
         #
         # replace skeleton values by real ones
 
@@ -758,12 +761,15 @@ class Tei:
                 pagenum = mets.get_orderlabel(struct_link) or mets.get_order(struct_link)
                 if pagenum:
                     pb.set("n", str(pagenum))
-                pb.set("corresp", mets.get_img(struct_link))
+                if 'page' in self.corresp:
+                    pb.set("corresp", mets.get_img(struct_link))
 
                 for text_block in alto.get_text_blocks():
                     p = etree.SubElement(node, "%sp" % TEI)
                     for line in alto.get_lines_in_text_block(text_block):
                         lb = etree.SubElement(p, "%slb" % TEI)
+                        if 'line' in self.corresp:
+                            lb.set("corresp", line.get("ID"))
                         line_text = alto.get_text_in_line(line)
                         if line_text:
                             lb.tail = line_text

--- a/mets_mods2tei/api/tei.py
+++ b/mets_mods2tei/api/tei.py
@@ -769,7 +769,11 @@ class Tei:
                     for line in alto.get_lines_in_text_block(text_block):
                         lb = etree.SubElement(p, "%slb" % TEI)
                         if 'line' in self.corresp:
-                            lb.set("corresp", line.get("ID"))
+                            line_id = line.get("ID")
+                            if not line_id:
+                                block = line.getparent()
+                                line_id = block.get("ID") + '_%04d' % block.index(line)
+                            lb.set("corresp", line_id)
                         line_text = alto.get_text_in_line(line)
                         if line_text:
                             lb.tail = line_text

--- a/mets_mods2tei/api/tei.py
+++ b/mets_mods2tei/api/tei.py
@@ -28,8 +28,9 @@ class Tei:
         The constructor.
         """
 
-        self.tree = etree.parse(os.path.realpath(resource_filename(Requirement.parse("mets_mods2tei"), 'mets_mods2tei/data/tei_skeleton.xml')))
-
+        skeleton = os.path.realpath(resource_filename(Requirement.parse("mets_mods2tei"),
+                                                      'mets_mods2tei/data/tei_skeleton.xml'))
+        self.tree = etree.parse(skeleton)
         self.alto_map = {}
 
         # logging
@@ -39,8 +40,9 @@ class Tei:
         """
         Serializes the TEI object as xml string.
         """
-        # needs lxml>=4.5: etree.indent(self.tree, space="  ")
-        return etree.tostring(self.tree, encoding="utf-8")
+        # needs lxml>=4.5:
+        etree.indent(self.tree, space="  ")
+        return etree.tostring(self.tree, pretty_print=True, encoding="utf-8")
 
     def fill_from_mets(self, mets, ocr=True):
         """

--- a/mets_mods2tei/scripts/mets_mods2tei.py
+++ b/mets_mods2tei/scripts/mets_mods2tei.py
@@ -16,15 +16,22 @@ from mets_mods2tei import Tei
 @click.option('-o', '--ocr', is_flag=True, default=False, help="Serialize OCR into resulting TEI")
 @click.option('-T', '--text-group', default="FULLTEXT", help="File group which contains the full-text")
 @click.option('-I', '--img-group', default="DEFAULT", help="File group which contains the images")
+@click.option('-r', '--add-refs', type=click.Choice(['page', 'line']), multiple=True, default=['page'])
 @click.option('-l', '--log-level', type=click.Choice(['DEBUG', 'INFO', 'WARN', 'ERROR', 'OFF']), default='WARN')
-def cli(mets, output, ocr, text_group, img_group, log_level):
+def cli(mets, output, ocr, text_group, img_group, add_refs, log_level):
     """METS: File containing or URL pointing to the METS/MODS XML to be converted
 
     Parse given METS and its meta-data, and convert it to TEI.
 
-    If `--ocr` is given, then also read the ALTO full-text files from the fileGrp in `--text-group`,
-    and convert page contents accordingly (in physical order). Decorate page boundaries with image
-    and page numbers, and reference the corresponding base image files from `--img-group`.
+    If `--ocr` is given, then also read the ALTO full-text files
+    from the fileGrp in `--text-group`, and convert page contents
+    accordingly (in physical order).
+
+    Decorate page boundaries with image and page numbers. Moreover,
+    if `--add-refs` contains `page`, then reference the corresponding
+    base image files (by file name) from `--img-group`. Likewise,
+    if `--add-refs` contains `line`, then reference the corresponding
+    textline segments (by XML ID) from `--text-group`.
 
     Output XML to `--output (use '-' for stdout), log to stderr.`
     """
@@ -53,7 +60,7 @@ def cli(mets, output, ocr, text_group, img_group, log_level):
     # create TEI (from skeleton)
     tei = Tei()
 
-    tei.fill_from_mets(mets, ocr)
+    tei.fill_from_mets(mets, ocr, corresp=add_refs)
 
     output.write(tei.tostring())
 


### PR DESCRIPTION
Allows adding `@corresp` to every `tei:lb` pointing to `alto:TextLine/@ID`.

Makes `@corresp` at every `tei:pb` (pointing to the image filename) optional.