### PR TITLE
Add GitHub Action for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,14 +3,14 @@ name: Python CI/CD
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     branches:
-      - main
+      - master
   workflow_dispatch:
   release:
     types:
-      - created
+      - published
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,75 @@
+name: Python CI/CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+  release:
+    types:
+      - created
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          make deps deps-test
+
+      - name: Install project
+        run: make install
+
+      - name: Run tests
+        run: make test
+
+      - name: Run coverage
+        run: make coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+
+  deploy:
+    name: Deploy to PyPI
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip build
+          make install
+
+      - name: Build package
+        run: python -m build .
+
+      - name: Upload to PyPI
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          pip install --upgrade pip twine
+          twine upload dist/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9, 3.10, 3.11]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up Python 3.7
+      - name: Set up Python 3.9
         uses: actions/setup-python@v5
         with:
-          python-version: 3.7
+          python-version: 3.9
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11, 3.12, 3.13]
+        python-version: [3.9, 3.10, 3.11]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # mets-mods2tei
 
-[![CircleCI](https://circleci.com/gh/slub/mets-mods2tei.svg?style=svg)](https://circleci.com/gh/slub/mets-mods2tei)
-[![codecov](https://codecov.io/gh/slub/mets-mods2tei/branch/master/graph/badge.svg)](https://codecov.io/gh/slub/mets-mods2tei)
-[![PyPI version](https://badge.fury.io/py/mets-mods2tei.svg)](https://badge.fury.io/py/mets-mods2tei)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/rettinghaus/mets-mods2tei/ci.yml?logo=GitHub)](https://github.com/slub/mets-mods2tei/actions)
+[![CircleCI](https://img.shields.io/circleci/build/github/slub/mets-mods2tei?logo=CircleCI)](https://circleci.com/gh/slub/mets-mods2tei)
+[![Codecov](https://img.shields.io/codecov/c/github/slub/mets-mods2tei?logo=Codecov)](https://codecov.io/gh/slub/mets-mods2tei)
+[![PyPI - Version](https://img.shields.io/pypi/v/mets-mods2tei?logo=PyPI)](https://pypi.org/project/mets-mods2tei/)
+[![GitHub License](https://img.shields.io/github/license/slub/mets-mods2tei)](LICENSE)
 
 Convert bibliographic meta data in METS/MODS format to TEI headers and optionally serialize linked ALTO-encoded OCR to TEI text.
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ For the TEI Header, the conversion is roughly based on the [*DTA base format*](h
 
 ## Installation
 
-`mets-mods2tei` is implemented in Python 3. In the following, we assume a working Python 3
-(tested versions 3.5, 3.6 and 3.7) installation.
+`mets-mods2tei` is implemented in Python 3. In the following, we assume a working Python 3 (tested versions 3.9, 3.10 and 3.11) installation.
 
 ### Setup Python
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mets-mods2tei
 
-[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/rettinghaus/mets-mods2tei/ci.yml?logo=GitHub)](https://github.com/slub/mets-mods2tei/actions)
+[![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/slub/mets-mods2tei/ci.yml?logo=GitHub)](https://github.com/slub/mets-mods2tei/actions)
 [![CircleCI](https://img.shields.io/circleci/build/github/slub/mets-mods2tei?logo=CircleCI)](https://circleci.com/gh/slub/mets-mods2tei)
 [![Codecov](https://img.shields.io/codecov/c/github/slub/mets-mods2tei?logo=Codecov)](https://codecov.io/gh/slub/mets-mods2tei)
 [![PyPI - Version](https://img.shields.io/pypi/v/mets-mods2tei?logo=PyPI)](https://pypi.org/project/mets-mods2tei/)

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ For the TEI Header, the conversion is roughly based on the [*DTA base format*](h
 
 ## Installation
 
-`mets-mods2tei` is implemented in Python 3. In the following, we assume a working Python 3 (tested versions 3.9, 3.10 and 3.11) installation.
+`mets-mods2tei` is implemented in Python 3. In the following, we assume a working Python 3 installation.
 
 ### Setup Python
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=('tests', 'docs')),
     package_data={'mets_mods2tei' : ['data/tei_skeleton.xml', 'data/iso15924-utf8-20180827.txt']},
     install_requires=open('requirements.txt').read().split('\n'),
-    python_requires=">=3.7",
+    python_requires=">=3.9",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -23,7 +23,10 @@ setup(
         'Intended Audience :: Information Technology',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Programming Language :: Python',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Topic :: Text Processing :: Markup :: XML',
     ],
     entry_points={


### PR DESCRIPTION
This adds a GH Action for testing and deploying. 
I couldn't test the step for the upload to PyPI. 

NB: Because of the removal of `distutils` in Python 3.12 it is only tested up to 3.11. 

CircleCI could then be removed.
