### PR TITLE
fix: remove double init of members

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,8 +213,6 @@ Options:
   -u, --url-prefix TEXT    URL prefix to add to path before storing references
                            (or else keep local file refs)
   --help                   Show this message and exit.
-
-
 ```
 
 </p></details>

--- a/mets_mods2tei/api/mets.py
+++ b/mets_mods2tei/api/mets.py
@@ -65,6 +65,7 @@ class Mets:
         """
         self.script_iso: Iso15924 = Iso15924()
         self.tree: Optional[etree._ElementTree] = None
+        self.wd: str = os.getcwd()
         self.mets: Optional[Any] = None
         self.mods: Optional[Any] = None
         self.page_map: Dict[str, Any] = {}
@@ -107,48 +108,6 @@ class Mets:
 
         # Logging
         self.logger: logging.Logger = logging.getLogger(__name__)
-
-        self.tree = None
-        self.wd = os.getcwd()
-        self.mets = None
-        self.mods = None
-        self.page_map = {}
-        self.order_map = {}
-        self.orderlabel_map = {}
-        self.img_map = {}
-        self.alto_map = {}
-        self.struct_links = {}
-        self.fulltext_group_name = 'FULLTEXT'
-        self.image_group_name = 'DEFAULT'
-
-        self.title = None
-        self.sub_titles = None
-        self.part_titles = None
-        self.volume_titles = None
-        self.authors = None
-        self.editors = None
-        self.places = None
-        self.dates = None
-        self.notes = None
-        self.publishers = None
-        self.edition = None
-        self.digital_origin = None
-        self.owner_digital = None
-        self.license = None
-        self.license_url = None
-        self.encoding_date = None
-        self.encoding_desc = None
-        self.location_phys = None
-        self.location_urls = None
-        self.shelf_locators = None
-        self.identifiers = None
-        self.scripts = None
-        self.collections = None
-        self.languages = None
-        self.classifications = None
-        self.subjects = None
-        self.extents = None
-        self.series = None
 
     @classmethod
     def read(cls, source: Union[str, IO]) -> 'Mets':

--- a/mets_mods2tei/api/mets_generateds.py
+++ b/mets_mods2tei/api/mets_generateds.py
@@ -133,7 +133,7 @@ except ImportError:
 try:
     from generatedssuper import GeneratedsSuper
 except ImportError as exp:
-    
+
     class GeneratedsSuper(object):
         tzoff_pattern = re_.compile(r'(\+|-)((0\d|1[0-3]):[0-5]\d|14:00)$')
         class _FixedOffsetTZ(datetime_.tzinfo):
@@ -527,8 +527,7 @@ except ImportError as exp:
             return 0, None
         def gds_sqa_etl_transform_db_obj(self, dbobj):
             pass
-    
-    
+
     def getSubclassFromModule_(module, class_):
         """Get the subclass of a class from a specific module."""
         name = class_.__name__ + 'Sub'

--- a/mets_mods2tei/api/tei.py
+++ b/mets_mods2tei/api/tei.py
@@ -479,9 +479,9 @@ class Tei:
         """
         Set the level of publication:
         - 'm': (monographic) the title applies to a monograph such as a book
-               or other item considered to be a distinct publication, 
+               or other item considered to be a distinct publication,
                including single volumes of multi-volume works
-        - 'a': (analytic) the title applies to an analytic item, such as an article, 
+        - 'a': (analytic) the title applies to an analytic item, such as an article,
                poem, or other work published as part of a larger item.
         - 'j': (journal) the title applies to any serial or periodical publication
                such as a journal, magazine, or newspaper

--- a/mets_mods2tei/data/iso15924-utf8-20180827.txt
+++ b/mets_mods2tei/data/iso15924-utf8-20180827.txt
@@ -1,7 +1,7 @@
 #
 # ISO 15924 - Codes for the representation of names of scripts
 #             Codes pour la représentation des noms d’écritures
-# Format: 
+# Format:
 #             Code;N°;English Name;Nom français;PVA;Unicode Version;Date
 #
 

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -163,9 +163,9 @@ def test_mappings_only_phys(subtests, datadir):
         assert mets.get_img('PHYS_0005') == 'https://digital.slub-dresden.de/data/kitodo/BurgAbha_1852685697/BurgAbha_1852685697_tif/jpegs/00000005.tif.original.jpg'
 
 def test_mappings_only_phys_local(subtests, datadir):
-    '''
+    """
     Test the correct interpretation of local file references
-    '''
+    """
     f = open(datadir.join('test_mets_nodiv_local.xml'))
     mets = Mets()
     mets.image_group_name = 'ORIGINAL'

--- a/tests/test_tei.py
+++ b/tests/test_tei.py
@@ -57,9 +57,9 @@ def test_reading_local_file(subtests, datadir):
         assert len(tei.tree.xpath('/tei:TEI/tei:text/tei:body//tei:div//tei:p//tei:lb', namespaces=NS)) > 8000
 
 def test_reading_local_file_local_ocr(subtests, datadir):
-    '''
+    """
     Test reading from a local mets file, referencing local alto files
-    '''
+    """
     f = open(datadir.join('test_mets_nodiv_local.xml'))
     mets = Mets.read(f)
     tei = Tei()
@@ -71,9 +71,9 @@ def test_reading_local_file_local_ocr(subtests, datadir):
         assert len(tei.tree.xpath('/tei:TEI/tei:text/tei:body//tei:div//tei:p//tei:lb', namespaces=NS)) > 800
 
 def test_reading_remote_url(tmpdir):
-    '''
+    """
     Test reading from a remote mets link
-    '''
+    """
     from urllib.request import urlopen
     mets = Mets()
     mets.fromfile(urlopen("https://digital.slub-dresden.de/oai/?verb=GetRecord&metadataPrefix=mets"


### PR DESCRIPTION
Something went wrong during rebase and we ended up with doubled declarations in mets class.