### PR TITLE
Modernize test infrastructure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
       - codecov/upload
   pypi:
     docker:
-      - image: cimg/python:3.8
+      - image: cimg/python:3.9
     working_directory: ~/repo
     steps:
       - checkout
@@ -46,7 +46,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['3.8', '3.9', '3.10', '3.11']
+              version: ['3.9', '3.10', '3.11', '3.12', '3.13']
   deploy:
     jobs:
       - pypi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+              version: ['3.10', '3.11', '3.12', '3.13', '3.14']
   deploy:
     jobs:
       - pypi:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,11 +1,11 @@
 # Python CircleCI 2.1 configuration file
 # for mets-mods2tei
 #
-# Check https://circleci.com/docs/2.0/language-python/ for more details
+# Check https://circleci.com/docs/guides/getting-started/language-python/ for more details
 #
 version: 2.1
 orbs:
-  codecov: codecov/codecov@1.0.5
+  codecov: codecov/codecov@5.4.3
 jobs:
   test:
     parameters:
@@ -24,7 +24,7 @@ jobs:
       - codecov/upload
   pypi:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.11
     working_directory: ~/repo
     steps:
       - checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         run: make coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
 
   deploy:
     name: Deploy to PyPI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- update test infrastructure
 
 ## [0.1.6] - 2025-09-25
 ### Added

--- a/mets_mods2tei/api/util.py
+++ b/mets_mods2tei/api/util.py
@@ -1,9 +1,4 @@
-# cannot use importlib.resources until we move to 3.9+ for importlib.resources.files
-import sys
-if sys.version_info < (3, 10):
-    import importlib_resources
-else:
-    import importlib.resources as importlib_resources
+from importlib.resources import files
 
 def resource_filename(pkg, fname):
-    return importlib_resources.files(pkg) / fname
+    return files(pkg) / fname

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-pytest >= 4.4.0
-pytest-ordering
+pytest >= 8.0.0
+pytest-order >= 1.0.0
 pytest-subtests
-coverage >= 4.5.2
+coverage >= 7.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 click
 lxml
 babel
-importlib_resources ; python_version < '3.10'
 generateDS
 rapidfuzz
-more-itertools
 ocrd >= 2.59

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=('tests', 'docs')),
     package_data={'mets_mods2tei' : ['data/tei_skeleton.xml', 'data/iso15924-utf8-20180827.txt']},
     install_requires=open('requirements.txt').read().split('\n'),
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -27,6 +27,8 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
+        'Programming Language :: Python :: 3.13',
         'Topic :: Text Processing :: Markup :: XML',
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     packages=find_packages(exclude=('tests', 'docs')),
     package_data={'mets_mods2tei' : ['data/tei_skeleton.xml', 'data/iso15924-utf8-20180827.txt']},
     install_requires=open('requirements.txt').read().split('\n'),
-    python_requires=">=3.9",
+    python_requires=">=3.10",
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
@@ -24,11 +24,11 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3.13',
+        'Programming Language :: Python :: 3.14',
         'Topic :: Text Processing :: Markup :: XML',
     ],
     entry_points={

--- a/tests/test_alto.py
+++ b/tests/test_alto.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import os
+from pathlib import Path
+
 import pytest
-import shutil
 
 from mets_mods2tei import Alto
 
@@ -13,12 +13,13 @@ def datadir(tmpdir, request):
     module and, if available, moving all contents to a temporary directory so
     tests can use them freely.
     """
-    filename = request.module.__file__
-    test_dir, _ = os.path.splitext(filename)
-
-    if os.path.isdir(test_dir):
-        shutil.copytree(test_dir, str(tmpdir), dirs_exist_ok=True)
-
+    src = Path(request.module.__file__).with_suffix('')
+    if src.is_dir():
+        for src_path in src.glob('**/*'):
+            if src_path.is_file():
+                dest_path = Path(str(tmpdir)) / src_path.relative_to(src)
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                dest_path.write_bytes(src_path.read_bytes())
     return tmpdir
 
 def test_constructor():

--- a/tests/test_alto.py
+++ b/tests/test_alto.py
@@ -2,13 +2,7 @@
 
 import os
 import pytest
-import warnings
-
-# the import of dir_util introduces a deprecation warning
-# we can't do much about it
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from distutils import dir_util
+import shutil
 
 from mets_mods2tei import Alto
 
@@ -23,7 +17,7 @@ def datadir(tmpdir, request):
     test_dir, _ = os.path.splitext(filename)
 
     if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, str(tmpdir))
+        shutil.copytree(test_dir, str(tmpdir), dirs_exist_ok=True)
 
     return tmpdir
 

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import os
+from pathlib import Path
+
 import pytest
-import shutil
 
 from mets_mods2tei import Mets
 
@@ -13,12 +13,13 @@ def datadir(tmpdir, request):
     module and, if available, moving all contents to a temporary directory so
     tests can use them freely.
     """
-    filename = request.module.__file__
-    test_dir, _ = os.path.splitext(filename)
-
-    if os.path.isdir(test_dir):
-        shutil.copytree(test_dir, str(tmpdir), dirs_exist_ok=True)
-
+    src = Path(request.module.__file__).with_suffix('')
+    if src.is_dir():
+        for src_path in src.glob('**/*'):
+            if src_path.is_file():
+                dest_path = Path(str(tmpdir)) / src_path.relative_to(src)
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                dest_path.write_bytes(src_path.read_bytes())
     return tmpdir
 
 def test_constructor():

--- a/tests/test_mets.py
+++ b/tests/test_mets.py
@@ -2,13 +2,7 @@
 
 import os
 import pytest
-import warnings
-
-# the import of dir_util introduces a deprecation warning
-# we can't do much about it
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from distutils import dir_util
+import shutil
 
 from mets_mods2tei import Mets
 
@@ -23,7 +17,7 @@ def datadir(tmpdir, request):
     test_dir, _ = os.path.splitext(filename)
 
     if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, str(tmpdir))
+        shutil.copytree(test_dir, str(tmpdir), dirs_exist_ok=True)
 
     return tmpdir
 

--- a/tests/test_tei.py
+++ b/tests/test_tei.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 
-import os
+from pathlib import Path
+
 import pytest
-import shutil
 
 from mets_mods2tei import Tei
 from mets_mods2tei import Mets
@@ -18,12 +18,13 @@ def datadir(tmpdir, request):
     module and, if available, moving all contents to a temporary directory so
     tests can use them freely.
     """
-    filename = request.module.__file__
-    test_dir, _ = os.path.splitext(filename)
-
-    if os.path.isdir(test_dir):
-        shutil.copytree(test_dir, str(tmpdir), dirs_exist_ok=True)
-
+    src = Path(request.module.__file__).with_suffix('')
+    if src.is_dir():
+        for src_path in src.glob('**/*'):
+            if src_path.is_file():
+                dest_path = Path(str(tmpdir)) / src_path.relative_to(src)
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                dest_path.write_bytes(src_path.read_bytes())
     return tmpdir
 
 def test_constructor():

--- a/tests/test_tei.py
+++ b/tests/test_tei.py
@@ -2,13 +2,7 @@
 
 import os
 import pytest
-import warnings
-
-# the import of dir_util introduces a deprecation warning
-# we can't do much about it
-with warnings.catch_warnings():
-    warnings.simplefilter("ignore")
-    from distutils import dir_util
+import shutil
 
 from mets_mods2tei import Tei
 from mets_mods2tei import Mets
@@ -28,7 +22,7 @@ def datadir(tmpdir, request):
     test_dir, _ = os.path.splitext(filename)
 
     if os.path.isdir(test_dir):
-        dir_util.copy_tree(test_dir, str(tmpdir))
+        shutil.copytree(test_dir, str(tmpdir), dirs_exist_ok=True)
 
     return tmpdir
 


### PR DESCRIPTION
This PR replaces `os` and `distutils` packages with `pathlib` making it work with current and future Python versions. 
This also is the more robust file handling solution across platforms.

Closes #79.